### PR TITLE
Update external GitHub workflows

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate graphs
-        uses: upptime/uptime-monitor@v1.41.9
+        uses: upptime/uptime-monitor@v1.41.10
         with:
           command: "graphs"
         env:

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.9
+        uses: upptime/uptime-monitor@v1.41.10
         with:
           command: "response-time"
         env:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -28,25 +28,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update template
-        uses: upptime/uptime-monitor@v1.41.9
+        uses: upptime/uptime-monitor@v1.41.10
         with:
           command: "update-template"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.9
+        uses: upptime/uptime-monitor@v1.41.10
         with:
           command: "response-time"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.9
+        uses: upptime/uptime-monitor@v1.41.10
         with:
           command: "readme"
         env:
@@ -57,7 +57,7 @@ jobs:
           workflow: Graphs CI
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.9
+        uses: upptime/uptime-monitor@v1.41.10
         with:
           command: "site"
         env:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -31,12 +31,12 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.9
+        uses: upptime/uptime-monitor@v1.41.10
         with:
           command: "site"
         env:

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.9
+        uses: upptime/uptime-monitor@v1.41.10
         with:
           command: "readme"
         env:

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Check endpoint status
-        uses: upptime/uptime-monitor@v1.41.9
+        uses: upptime/uptime-monitor@v1.41.10
         with:
           command: "update"
         env:


### PR DESCRIPTION
Updates from `gh-external-audit update`:

- actions/checkout: v5 → v6 (major tag)
- upptime/uptime-monitor: v1.41.9 → v1.41.10 (exact tag) — v1.41.10 bug-fix: serialize generated workflow writes

Not updated:

- upptime/updates: master (kept) — latest tag v1.0.1 (2020-12-02) is OLDER than current master HEAD (2021-03-08); pinning to v1.0.1 would be a downgrade. Also @master is a branch pin (security flag) — needs upstream review
